### PR TITLE
fix: remove the legacy Notifiability

### DIFF
--- a/strategy.go
+++ b/strategy.go
@@ -21,8 +21,6 @@ func init() {
 }
 
 type Strategy struct {
-	Notifiability *bbgo.Notifiability
-
 	Symbol            string           `json:"symbol"`
 	Quantity          fixedpoint.Value `json:"quantity"`
 	Gap               fixedpoint.Value `json:"gap,omitempty"`


### PR DESCRIPTION
The API was upgraded, you can call `bbgo.Notify` to send the notifications~

